### PR TITLE
Remove Google Analytics ID from original repo

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,6 @@ github_username:  VincentWang25
 
 markdown: kramdown
 remote_theme: jekyll/minima
-google_analytics: G-6SRK9DNEMH
 
 plugins:
   - jekyll-feed


### PR DESCRIPTION
Hi @VincentWang25,

I noticed that you seem to have copied my code for my personal website at https://cmsflash.github.io/. Within it, you have not removed or changed the Google Analytics ID. This issue causes your site's traffic to appear on my own traffic analytics. Please accept this PR to remove the ID.